### PR TITLE
fix nltk punkt_tab bugs in prepare.py

### DIFF
--- a/scripts/data/prepare.py
+++ b/scripts/data/prepare.py
@@ -41,9 +41,10 @@ from template import Templates
 import nltk
 try:
     nltk.data.find('tokenizers/punkt')
+    nltk.data.find('tokenizers/punkt_tab')
 except LookupError:
     nltk.download('punkt')
- 
+    nltk.download('punkt_tab')
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--save_dir", type=Path, required=True, help='dataset folder to save dataset')


### PR DESCRIPTION
I met the same problem with #69 when testing Llama-3.1-8b-Instruct on "niah_single_2", "niah_single_3" and so on tasks. And I found it was caused by the missing of nltk/tokenizers/punkt_tab files, cuz you might step into the following issue:

```
Traceback (most recent call last):
  File "/workspace/benchmark/RULER/scripts/data/synthetic/niah.py", line 271, in <module>
    main()
  File "/workspace/benchmark/RULER/scripts/data/synthetic/niah.py", line 262, in main
    write_jsons = generate_samples(
  File "/workspace/benchmark/RULER/scripts/data/synthetic/niah.py", line 215, in generate_samples
    input_text, answer = generate_input_output(num_haystack)
  File "/workspace/benchmark/RULER/scripts/data/synthetic/niah.py", line 143, in generate_input_output
    document_sents = sent_tokenize(text.strip())
  File "/usr/local/lib/python3.10/dist-packages/nltk/tokenize/__init__.py", line 119, in sent_tokenize
    tokenizer = _get_punkt_tokenizer(language)
  File "/usr/local/lib/python3.10/dist-packages/nltk/tokenize/__init__.py", line 105, in _get_punkt_tokenizer
    return PunktTokenizer(language)
  File "/usr/local/lib/python3.10/dist-packages/nltk/tokenize/punkt.py", line 1744, in __init__
    self.load_lang(lang)
  File "/usr/local/lib/python3.10/dist-packages/nltk/tokenize/punkt.py", line 1749, in load_lang
    lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
  File "/usr/local/lib/python3.10/dist-packages/nltk/data.py", line 579, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource punkt_tab not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt_tab')

  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt_tab/english/

  Searched in:
    - '/root/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************

```

And this can be fixed using this commit :)