### PR TITLE
refactor vllm cli arg parser to FlexibleArgumentParser

### DIFF
--- a/scripts/pred/serve_vllm.py
+++ b/scripts/pred/serve_vllm.py
@@ -14,7 +14,7 @@
 
 # adapted from https://github.com/vllm-project/vllm/blob/v0.4.0/vllm/entrypoints/api_server.py
 
-import argparse
+
 import json
 from typing import AsyncGenerator
 
@@ -26,6 +26,7 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
+from vllm.utils import FlexibleArgumentParser
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 app = FastAPI()
@@ -85,7 +86,10 @@ async def generate(request: Request) -> Response:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = FlexibleArgumentParser(
+        description="vLLM API server for serving LLMs asynchronously",
+        epilog="For more information, see https://docs.vllm.ai/en/stable/configuration/engine_args.html",
+    )
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=5000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)


### PR DESCRIPTION
`FlexibleArgumentParser` is introduced in `vllm==0.5.1`, this is a dedicated cli arg parser for vllm.

This avoids compatibility issues caused by using the standard `argparse.ArgumentParser`, particularly with the `deprecated` option.  

For details, see [related PR #17426](https://github.com/vllm-project/vllm/pull/17426).